### PR TITLE
[#1] Feat: Add sleep wakeup 기능 구현

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -93,8 +93,10 @@ timer_sleep (int64_t ticks) {
 	int64_t start = timer_ticks ();
 
 	ASSERT (intr_get_level () == INTR_ON);
-	while (timer_elapsed (start) < ticks)
-		thread_yield ();
+
+	/* tick 경과 시간과 sleep 요청 tick 시간 비교 후 스레드 슬립 처리 */
+	if(timer_elapsed(start) < ticks)
+		thread_sleep(start + ticks);
 }
 
 /* Suspends execution for approximately MS milliseconds. */
@@ -122,10 +124,11 @@ timer_print_stats (void) {
 }
 
 /* Timer interrupt handler. */
-static void
-timer_interrupt (struct intr_frame *args UNUSED) {
+static void timer_interrupt(struct intr_frame *args UNUSED)
+{
 	ticks++;
-	thread_tick ();
+	thread_tick();
+	thread_wakeup(ticks);
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -91,6 +91,7 @@ struct thread {
 	enum thread_status status;          /* Thread state. */
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
+	int64_t wakeup_ticks;	   			/* tick till wake up */
 
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
@@ -119,6 +120,11 @@ void thread_start (void);
 
 void thread_tick (void);
 void thread_print_stats (void);
+
+// 스레드 잠 재울 시간 / 잠 깨울 시간
+void thread_sleep (int64_t ticks);
+void thread_wakeup (int64_t global_ticks);
+bool compare_thread_ticks(const struct list_elem *a, const struct list_elem *b, void *aux);
 
 typedef void thread_func (void *aux);
 tid_t thread_create (const char *name, int priority, thread_func *, void *);

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -27,6 +27,9 @@
    that are ready to run but not actually running. */
 static struct list ready_list;
 
+/* timer_sleep() 호출될 경우 기존 running 되는 프로세스/스레드 -> sleep_list   */
+static struct list sleep_list;
+
 /* Idle thread. */
 static struct thread *idle_thread;
 
@@ -107,6 +110,7 @@ thread_init (void) {
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
 	list_init (&ready_list);
+	list_init (&sleep_list);
 	list_init (&destruction_req);
 
 	/* Set up a thread structure for the running thread. */
@@ -151,6 +155,52 @@ thread_tick (void) {
 	/* Enforce preemption. */
 	if (++thread_ticks >= TIME_SLICE)
 		intr_yield_on_return ();
+}
+
+void thread_wakeup(int64_t current_ticks)
+{
+	enum intr_level old_level = intr_disable(); // 인터럽트 비활성화
+
+	struct list_elem *curr_elem = list_begin(&sleep_list); // sleep_list의 첫번째 요소(빈 경우 NULL)
+	while (curr_elem != list_end(&sleep_list))
+	{
+		struct thread *curr_thread = list_entry(curr_elem, struct thread, elem); // 현재 검사중인 elem의 스레드
+
+		if (current_ticks >= curr_thread->wakeup_ticks) // 깰 시간이 됐으면
+		{
+			curr_elem = list_remove(curr_elem); // sleep_list에서 제거 & curr_elem에는 다음 elem이 담김
+			thread_unblock(curr_thread);		// ready_list로 이동
+		}
+		else
+			break;
+	}
+	intr_set_level(old_level); // 인터럽트 상태를 원래 상태로 변경
+}
+
+void
+thread_sleep (int64_t ticks) {
+	struct thread *curr = thread_current();	 // 현재 스레드;
+	enum intr_level old_level;
+
+	ASSERT(curr != idle_thread); // 현재 스레드가 idle이 아닐 때만
+
+	old_level = intr_disable(); // 인터럽트 비활성
+	curr->wakeup_ticks = ticks;	 // 일어날 시각 저장
+
+	// sleep_list에 있는 원소들과 wakeup_ticks를 비교하면서 삽입될 위치 찾아서 삽입하기
+	list_insert_ordered(&sleep_list, &curr->elem, compare_thread_ticks, NULL);
+	thread_block(); // 현재 스레드 재우기
+
+	intr_set_level(old_level); // 인터럽트 상태를 원래 상태로 변경
+}
+
+/* a와 b 스레드의 wakeup_ticks를 비교해서 작으면 true를 반환하는 함수 */
+bool
+compare_thread_ticks(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED)
+{
+	struct thread *st_a = list_entry(a, struct thread, elem);
+	struct thread *st_b = list_entry(b, struct thread, elem);
+	return st_a->wakeup_ticks < st_b->wakeup_ticks;
 }
 
 /* Prints thread statistics. */


### PR DESCRIPTION
## 구현사항
- `thread.c`
	- [x] sleep_list 리스트 추가
	- [x] thread_wakeup 함수 추가
	- [x] thread_sleep 함수 추가
	- [x] compare_thread_ticks 함수 추가
- `timer.c`
	- [x] timer_interrupt 함수를 통해서 1 tick 마다 sleep_list 체크 (`thread_wakeup(ticks)`)
	- [x] timer_sleep 함수 수정 - tick 경과 시간과 sleep 요청 tick 시간 비교 후 스레드 슬립 처리

## 구현 방법
-  `void thread_sleep (int64_t ticks)`
	1. sleep 할 시간(`ticks`)을 인자로 받는다.
	2. 현재 스레드 정보를 가져온 뒤, wakeup_ticks 값을 `ticks` 로 변경한다.
	3. `list_insert_ordered` 함수를 통해 `sleep_list` 리스트에 있는 원소를 햐나씩 돌면서 `wakeup_ticks`과 `ticks`를 비교해서 `wakeup_ticks`가 커지면, 그 위치에 현재 스레드가 삽입된다.
	4. 현재 스레드를 sleep 상태로 변경한다. (`thread_block()`)
	5. 인터럽트 상태(초기에 저장한 `old_level`)로 복구시킨다.

- `void thread_wakeup(int64_t current_ticks)`
	1. `sleep_list`의 헤더를 가져온다.
	2. `sleep_list` 요소를 하나씩 돌면서 `wakeup_ticks`를 체크하면서, 깰 시간이 됬는지 체크한다.
	3. 만약 `wakeup_ticks` 가 현재 tick 보다 작으면, `sleep_list` 함수로 제거(`list_remove()`) 후, `ready_list`로 넣어줌(`thread_unblock()`)
	4. 만약 `wakeup_ticks` 가 현재 tick 보다 크다면, `break`를 사용해서 while문을 빠져온다.
		->  `sleep_list`가 요소를 넣을 때, `wakeup_ticks` 순의 오름차순으로 정렬되어 있기 때문에, 뒤에 요소들은 모두 깰 시간이 아니다.
	5. 인터럽트 상태(초기에 저장한 `old_level`)로 복구시킨다.

- `timer_interrupt()` 가 1 tick 마다 실행되는 함수이므로 `timer_interrupt()` 내부에 `thread_wakeup()` 함수도 같이 호출 될 수 있도록 한다.